### PR TITLE
feat: add user link management endpoints, UUID support, and soft delete

### DIFF
--- a/src/main/java/org/decepticons/linkshortener/api/controller/LinkController.java
+++ b/src/main/java/org/decepticons/linkshortener/api/controller/LinkController.java
@@ -1,7 +1,9 @@
 package org.decepticons.linkshortener.api.controller;
 
+
 import jakarta.validation.Valid;
 import java.util.Optional;
+import java.util.UUID;
 import org.decepticons.linkshortener.api.dto.LinkResponse;
 import org.decepticons.linkshortener.api.dto.UrlRequest;
 import org.decepticons.linkshortener.api.exception.NoSuchUserFoundInTheSystem;
@@ -10,13 +12,16 @@ import org.decepticons.linkshortener.api.model.User;
 import org.decepticons.linkshortener.api.repository.LinkRepository;
 import org.decepticons.linkshortener.api.repository.UserRepository;
 import org.decepticons.linkshortener.api.service.LinkService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -26,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/links")
 public class LinkController {
-
   private final LinkService linkService;
   private final LinkRepository linkRepository;
   private final UserRepository userRepository;
@@ -96,5 +100,48 @@ public class LinkController {
     return ResponseEntity.status(302)
         .header("Location", link.getOriginalUrl())
         .build();
+  }
+
+  /**
+   * Retrieves a paginated list of all user's links including active and inactive ones.
+   *
+   * @param page the page number to retrieve
+   * @param size the number of records per page
+   * @return {@link ResponseEntity} containing a {@link Page} of {@link LinkResponse} objects
+   */
+  @GetMapping("/my_all_links")
+  public ResponseEntity<Page<LinkResponse>> getAllMyLinks(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    return ResponseEntity.ok(linkService.getAllMyLinks(page, size));
+  }
+
+  /**
+   * Retrieves a paginated list of the current user's active links only.
+   *
+   * @param page the page number to retrieve
+   * @param size the number of records per page
+   * @return a {@link ResponseEntity} containing a {@link Page} of {@link LinkResponse} objects
+   */
+  @GetMapping("/my_all_active_links")
+  public ResponseEntity<Page<LinkResponse>> getAllMyActiveLinks(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    return ResponseEntity.ok(linkService.getAllMyActiveLinks(page, size));
+  }
+
+  /**
+   * Deletes a specific link belonging to the current user by its unique ID.
+   *
+   * @param id the unique identifier of the link to delete
+   * @return a {@link ResponseEntity} with HTTP status 204 (No Content)
+   *     if the deletion was successful
+   */
+  @DeleteMapping("/delete/{id}")
+  public ResponseEntity<Void> deleteLink(@PathVariable UUID id) {
+    linkService.deleteLink(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/decepticons/linkshortener/api/repository/LinkRepository.java
+++ b/src/main/java/org/decepticons/linkshortener/api/repository/LinkRepository.java
@@ -1,50 +1,54 @@
 package org.decepticons.linkshortener.api.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 import org.decepticons.linkshortener.api.model.Link;
+import org.decepticons.linkshortener.api.model.LinkStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 /**
- * Provides methods to interact with the database for Link entities.
+ * Repository interface for managing {@link Link} entities.
+ * Provides CRUD operations and custom queries for retrieving links by code, owner, and status.
  */
 @Repository
-public interface LinkRepository extends JpaRepository<Link, Long> {
+public interface LinkRepository extends JpaRepository<Link, UUID> {
 
   /**
-   * Finds a link by generated short URL.
+   * Finds a link by its unique short code.
    *
-   * @param code short URL code
-   * @return an optional containing the link if found
+   * @param code the short code of the link
+   * @return an {@link Optional} containing the {@link Link} if found, or empty if not found
    */
   Optional<Link> findByCode(String code);
 
   /**
-   * Verifies if a link exists by generated short URL.
+   * Checks whether a link with the specified short code exists.
    *
-   * @param code short URL code
-   * @return true if the link exists, false otherwise
+   * @param code the short code to check
+   * @return {@code true} if a link with the code exists, {@code false} otherwise
    */
   boolean existsByCode(String code);
 
   /**
-   * Finds all links by owner id.
+   * Retrieves all links belonging to a specific user with pagination support.
    *
-   * @param ownerId  owner id
-   * @param pageable pagination information
-   * @return a page of links
+   * @param ownerId  the UUID of the user (owner)
+   * @param pageable the {@link Pageable} object specifying page number, size, and sorting
+   * @return a {@link Page} of {@link Link} objects belonging to the specified user
    */
-  Page<Link> findAllByOwnerId(Long ownerId, Pageable pageable);
+  Page<Link> findAllByOwnerId(UUID ownerId, Pageable pageable);
 
   /**
-   * Finds all links by owner id and status.
+   * Retrieves all links belonging to a specific user that have a certain status,
+   *     with pagination support.
    *
-   * @param ownerId  owner id
-   * @param status   link status
-   * @param pageable pagination information
-   * @return a page of links
+   * @param ownerId  the UUID of the user (owner)
+   * @param status   the {@link LinkStatus} to filter links by (e.g., ACTIVE, INACTIVE)
+   * @param pageable the {@link Pageable} object specifying page number, size, and sorting
+   * @return a {@link Page} of {@link Link} objects belonging to the user with the specified status
    */
-  Page<Link> findAllByOwnerIdAndStatus(Long ownerId, String status, Pageable pageable);
+  Page<Link> findAllByOwnerIdAndStatus(UUID ownerId, LinkStatus status, Pageable pageable);
 }

--- a/src/main/java/org/decepticons/linkshortener/api/repository/UserRepository.java
+++ b/src/main/java/org/decepticons/linkshortener/api/repository/UserRepository.java
@@ -5,28 +5,25 @@ import org.decepticons.linkshortener.api.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-
-
 /**
- * Providing methods to interact with the database for User entities.
+ * Repository interface for managing {@link User} entities.
+ * Provides CRUD operations and custom queries for retrieving users by username.
  */
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
   /**
-   * Finds a user by their username.
+   * Finds a user by their unique username.
    *
-   * @param username the username to search.
-   * @return an optional containing the user if found
+   * @param username the username to search for
+   * @return an {@link Optional} containing the {@link User} if found, or empty if not found
    */
   Optional<User> findByUsername(String username);
 
-
   /**
-   * Verifies if a user exists by username.
+   * Checks whether a user with the specified username exists.
    *
-   * @param username the username to search.
-   * @return true if the user exists, false otherwise
+   * @param username the username to check
+   * @return {@code true} if a user with the username exists, {@code false} otherwise
    */
   boolean existsByUsername(String username);
 }

--- a/src/main/java/org/decepticons/linkshortener/api/service/LinkService.java
+++ b/src/main/java/org/decepticons/linkshortener/api/service/LinkService.java
@@ -2,13 +2,23 @@ package org.decepticons.linkshortener.api.service;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.decepticons.linkshortener.api.dto.LinkResponse;
 import org.decepticons.linkshortener.api.dto.UrlRequest;
+import org.decepticons.linkshortener.api.exception.NoSuchUserFoundInTheSystem;
 import org.decepticons.linkshortener.api.model.Link;
 import org.decepticons.linkshortener.api.model.LinkStatus;
 import org.decepticons.linkshortener.api.model.User;
 import org.decepticons.linkshortener.api.repository.LinkRepository;
+import org.decepticons.linkshortener.api.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class LinkService {
 
   private final LinkRepository linkRepository;
+  private final UserRepository userRepository;
   private final Random random = new Random();
+
 
   /**
    * Creates a new {@code LinkService}.
@@ -32,8 +44,9 @@ public class LinkService {
    * @param linkRepository repository used to persist and load {@link Link} entities
    */
 
-  public LinkService(LinkRepository linkRepository) {
+  public LinkService(LinkRepository linkRepository, UserRepository userRepository) {
     this.linkRepository = linkRepository;
+    this.userRepository = userRepository;
   }
 
 
@@ -129,4 +142,62 @@ public class LinkService {
   }
 
 
+  /**
+   * Retrieves all links of the currently authenticated user with pagination.
+   *
+   * @param page the page number to retrieve (0-based)
+   * @param size the number of records per page
+   * @return a {@link Page} of {@link LinkResponse} objects representing all user's links
+   */
+  public Page<LinkResponse> getAllMyLinks(int page, int size) {
+    UUID userId = getCurrentUserId();
+    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    return linkRepository.findAllByOwnerId(userId, pageable)
+        .map(this::mapToResponse);
+  }
+
+  /**
+   * Retrieves all active links of the currently authenticated user with pagination.
+   *
+   * @param page the page number to retrieve (0-based)
+   * @param size the number of records per page
+   * @return a {@link Page} of {@link LinkResponse} objects representing active user's links
+   */
+  public Page<LinkResponse> getAllMyActiveLinks(int page, int size) {
+    UUID userId = getCurrentUserId();
+    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    return linkRepository.findAllByOwnerIdAndStatus(userId, LinkStatus.ACTIVE, pageable)
+        .map(this::mapToResponse);
+  }
+
+  /**
+   * Marks a link as inactive (soft delete) if it belongs to the currently authenticated user.
+   *
+   * @param linkId the unique identifier of the link to delete
+   */
+  public void deleteLink(UUID linkId) {
+    UUID userId = getCurrentUserId();
+    linkRepository.findById(linkId)
+        .filter(link -> link.getOwner().getId().equals(userId))
+        .ifPresent(link -> {
+          link.setStatus(LinkStatus.INACTIVE);
+          linkRepository.save(link);
+        });
+  }
+
+  /**
+   * Retrieves the UUID of the currently authenticated user from the security context.
+   *
+   * @return the UUID of the authenticated user
+   */
+  private UUID getCurrentUserId() {
+    String username = SecurityContextHolder.getContext().getAuthentication().getName();
+    User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new NoSuchUserFoundInTheSystem(
+            "No such user found in the system: " + username,
+            username
+        ));
+    return user.getId();
+  }
 }
+


### PR DESCRIPTION
- GET /my_all_links and /my_all_active_links with pagination

- DELETE /delete/{id} for soft delete of user's links

- Repository and service updated to use UUID for ownerId

- Added Javadoc and Checkstyle compliance